### PR TITLE
Add Molecule test support for Ubuntu 16.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+.vagrant
+
+# Molecule
+*.log
 .cache
 __pycache__
 *.pyc
-.vagrant
 .molecule

--- a/molecule.yml
+++ b/molecule.yml
@@ -9,6 +9,9 @@ vagrant:
     - name: trusty64
       box: ubuntu/trusty64
 
+    - name: xenial64
+      box: ubuntu/xenial64
+
   providers:
     - name: virtualbox
       type: virtualbox

--- a/playbook.yml
+++ b/playbook.yml
@@ -8,20 +8,21 @@
     # an ansible dependency that isn't included by default in Ubuntu 16.04 and
     # up.
 
-    - raw: cat /etc/lsb-release | grep DISTRIB_RELEASE | cut -d "=" -f2
+    - name: Check ubuntu release
+      raw: cat /etc/lsb-release | grep DISTRIB_RELEASE | cut -d "=" -f2
       register: ubuntu_release
 
-    - debug: msg="Running ubuntu version {{ ubuntu_release.stdout|float }}"
+    - debug: msg="Running ubuntu version {{ ubuntu_release.stdout }}"
 
-  # Update apt cache and install python 2 for Ubuntu versions greater than 16.04
-
+    # Update apt cache and install python 2 for Ubuntu versions greater than 16.04
     - name: Update APT cache
       raw: apt-get update
-      become: yes
+      become: True
 
+    - name: Install python
       raw: apt-get install -yq python
-      become: yes
-      when: ubuntu_release.stdout| float >= 16.04
+      become: True
+      when: "{{ ubuntu_release.stdout| version_compare('16.04', '>=') }}"
 
     # Gather facts once ansible dependencies are installed
     - name: Gather facts

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,9 +1,31 @@
 ---
 - hosts: all
+  gather_facts: False
 
   pre_tasks:
+
+    # Check Ubuntu release version to determine if we need to install python 2,
+    # an ansible dependency that isn't included by default in Ubuntu 16.04 and
+    # up.
+
+    - raw: cat /etc/lsb-release | grep DISTRIB_RELEASE | cut -d "=" -f2
+      register: ubuntu_release
+
+    - debug: msg="Running ubuntu version {{ ubuntu_release.stdout|float }}"
+
+  # Update apt cache and install python 2 for Ubuntu versions greater than 16.04
+
     - name: Update APT cache
-      apt: update_cache=yes
+      raw: apt-get update
+      become: yes
+
+      raw: apt-get install -yq python
+      become: yes
+      when: ubuntu_release.stdout| float >= 16.04
+
+    # Gather facts once ansible dependencies are installed
+    - name: Gather facts
+      setup:
 
   roles:
     # Terraform


### PR DESCRIPTION
Add Molecule support for Ubuntu 16.04, which does not include Python 2 (an Ansible dependency) by default.
## Testing

Run `molecule create --platform=xenial64` to create a testing VM and switch the default testing platform to Ubuntu 16.04. This is done to address [a known molecule bug](https://github.com/metacloud/molecule/issues/199). Then run `molecule test` and ensure all tests pass.
