### PR TITLE
Update dependency rolespec

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,4 +13,5 @@ galaxy_info:
   - cloud
   - system
 dependencies:
-  - { role: "azavea.unzip" }
+  - src: azavea.unzip
+    version: 0.1.2


### PR DESCRIPTION
Update role spec format so that a deprecation warning is no longer raised when installing through `ansible-galaxy`

See:
- https://github.com/ansible/ansible/pull/14612
- https://github.com/ansible/ansible/blob/85f4c958437f1ed10cdca93492d8f1b9ce7f6ddf/lib/ansible/playbook/role/requirement.py#L154

---

**Testing**

In another directory, create a `roles.yml` file that installs the role from this branch of the`ansible-terraform` repository.

``` bash
$ cat roles.yml

- src: https://github.com/azavea/ansible-terraform/archive/feature/tnation/rolespec.tar.gz
  name: azavea.terraform
```

Then, install the role using `ansible-galaxy`.

``` bash
$ ansible-galaxy install -r roles.yml -p .        
- downloading role from https://github.com/azavea/ansible-terraform/archive/feature/tnation/rolespec.tar.gz
- extracting azavea.terraform to azavea.terraform
- azavea.terraform was installed successfully
- adding dependency: azavea.unzip
- downloading role 'unzip', owned by azavea
- downloading role from https://github.com/azavea/ansible-unzip/archive/0.1.2.tar.gz
- extracting azavea.unzip to azavea.unzip
- azavea.unzip was installed successfully
```
