### PR TITLE
Add role name to role dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,3 +15,4 @@ galaxy_info:
 dependencies:
   - src: azavea.unzip
     version: 0.1.2
+    name: azavea.unzip


### PR DESCRIPTION
Role dependencies without role names explicitly defined can throw errors under certain conditions when referenced via `ansible-galaxy`.

---

**Testing**

Hard to test this without doing so against a released version. I was testing with the instructions in https://github.com/azavea/ansible-terraform/pull/4, but those also seemed to work prior to this fix.

In setting up a new project, I had `roles.yml` with:

``` yaml
- src: azavea.terraform
  version: 0.3.0
```

That threw:

```
ERROR! role definitions must contain a role name

The error appears to have been in '/Users/hcastro/Projects/mmw-micro/deployment/ansible/roles/azavea.terraform/meta/main.yml': line 16, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

dependencies:
  - src: azavea.unzip
    ^ here

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

I resolved it by updating the `src` attribute to `https://github.com/azavea/ansible-terraform/archive/feature/hmc/role-name.tar.gz`.
