### PR TITLE
Fix Terraform version check

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-terraform_version: "0.6.16"
+terraform_version: "0.7.5"

--- a/molecule.yml
+++ b/molecule.yml
@@ -4,6 +4,15 @@ ansible:
   requirements_file: requirements.yml
   sudo: True
 
+molecule:
+  test:
+    sequence:
+      - destroy
+      - syntax
+      - create
+      - converge
+      - idempotence
+
 vagrant:
   platforms:
     - name: trusty64

--- a/playbook.yml
+++ b/playbook.yml
@@ -4,11 +4,11 @@
 
   pre_tasks:
 
-    # Check Ubuntu release version to determine if we need to install python 2,
+    # Check Ubuntu release version to determine if we need to install Python 2,
     # an ansible dependency that isn't included by default in Ubuntu 16.04 and
     # up.
 
-    - name: Check ubuntu release
+    - name: Check Ubuntu release
       raw: cat /etc/lsb-release | grep DISTRIB_RELEASE | cut -d "=" -f2
       register: ubuntu_release
 
@@ -19,7 +19,7 @@
       raw: apt-get update
       become: True
 
-    - name: Install python
+    - name: Install Python
       raw: apt-get install -yq python
       become: True
       when: "{{ ubuntu_release.stdout| version_compare('16.04', '>=') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,20 +1,17 @@
 ---
 - name: Check Terraform Version
-  shell: terraform --version | grep {{ terraform_version }}
+  shell: "terraform --version | head -n1 | grep {{ terraform_version }}"
+  failed_when: False
+  changed_when: False
   register: current_terraform_version
-
-  # Don't register ansible change if the proper version terraform is
-  # currently installed. Maintains idempotence for testing.
-
-  changed_when: current_terraform_version.rc != 0
-  ignore_errors: True
 
 - name: Download Terraform
   get_url: url="https://releases.hashicorp.com/terraform/{{ terraform_version }}/terraform_{{ terraform_version }}_linux_amd64.zip"
            dest="/usr/local/src/terraform_{{ terraform_version }}_linux_amd64.zip"
+  register: terraform_downloaded
 
 - name: Extract and install Terraform
-  unarchive: src=/usr/local/src/terraform_{{ terraform_version }}_linux_amd64.zip
+  unarchive: src="/usr/local/src/terraform_{{ terraform_version }}_linux_amd64.zip"
              dest=/usr/local/bin
              copy=no
-  when: current_terraform_version.rc != 0
+  when: current_terraform_version.rc != 0 or terraform_downloaded | changed


### PR DESCRIPTION
Ensure that this role installs the version of Terraform defined in `terraform_version` when it is not currently installed.

Also, update the default version of Terraform to 0.7.5.

---

**Testing**

First, compare the versions of Molecule and Ansible you have installed to these:

``` bash
❯ molecule --version
molecule, version 1.12.4

❯ ansible --version
ansible 2.1.2.0
  config file = /Users/hcastro/Projects/ansible-terraform/ansible.cfg
  configured module search path = Default w/o overrides
```

Next, `converge` across both platforms:

``` bash
❯ molecule converge --platform=all
```

Then, change the version of Terraform to be installed:

``` diff
diff --git a/defaults/main.yml b/defaults/main.yml
index c4a2a98..db30e75 100644
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-terraform_version: "0.7.5"
+terraform_version: "0.7.4"
```

Lastly, `converge` again and `login` to ensure that the correct version of Terraform is installed:

``` bash
❯ molecule converge --platform=all

❯ molecule login --host ansible-terraform-trusty64
Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
Welcome to Ubuntu 14.04.5 LTS (GNU/Linux 3.13.0-96-generic x86_64)

 * Documentation:  https://help.ubuntu.com/

  System information as of Mon Oct 10 15:09:24 UTC 2016

  System load:  0.01              Processes:           86
  Usage of /:   3.9% of 39.34GB   Users logged in:     0
  Memory usage: 27%               IP address for eth0: 10.0.2.15
  Swap usage:   0%

  Graph this data and manage this system at:
    https://landscape.canonical.com/

  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud

New release '16.04.1 LTS' available.
Run 'do-release-upgrade' to upgrade to it.


Last login: Mon Oct 10 15:10:05 2016 from 10.0.2.2
vagrant@ansible-terraform-trusty64:~$ terraform --version
Terraform v0.7.4

Your version of Terraform is out of date! The latest version
is 0.7.5. You can update by downloading from www.terraform.io

❯ molecule login --host ansible-terraform-xenial64
Warning: Permanently added '[127.0.0.1]:2200' (ECDSA) to the list of known hosts.
Welcome to Ubuntu 16.04.1 LTS (GNU/Linux 4.4.0-34-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  Get cloud support with Ubuntu Advantage Cloud Guest:
    http://www.ubuntu.com/business/services/cloud

71 packages can be updated.
32 updates are security updates.


Last login: Mon Oct 10 15:10:05 2016 from 10.0.2.2
ubuntu@ansible-terraform-xenial64:~$ terraform --version
Terraform v0.7.4

Your version of Terraform is out of date! The latest version
is 0.7.5. You can update by downloading from www.terraform.io
```
