### PR TITLE
Validate download against published Terraform checksum

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-terraform_version: "0.7.5"
+terraform_version: "0.9.11"

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,8 +1,11 @@
 ---
 ansible:
   config_file: ansible.cfg
+  become: True
+
+dependency:
+  name: galaxy
   requirements_file: requirements.yml
-  sudo: True
 
 molecule:
   test:
@@ -11,7 +14,6 @@ molecule:
       - syntax
       - create
       - converge
-      - idempotence
 
 vagrant:
   platforms:

--- a/playbook.yml
+++ b/playbook.yml
@@ -22,7 +22,7 @@
     - name: Install Python
       raw: apt-get install -yq python
       become: True
-      when: "{{ ubuntu_release.stdout| version_compare('16.04', '>=') }}"
+      when: ubuntu_release.stdout | version_compare('16.04', '>=')
 
     # Gather facts once ansible dependencies are installed
     - name: Gather facts

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,21 @@
 ---
-- name: Check Terraform Version
+- name: Check Terraform version
   shell: "terraform --version | head -n1 | grep {{ terraform_version }}"
   failed_when: False
   changed_when: False
   register: current_terraform_version
 
+- name: Determine Terraform checksums
+  uri: url="https://releases.hashicorp.com/terraform/{{ terraform_version }}/terraform_{{ terraform_version }}_SHA256SUMS"
+       method="GET"
+       return_content=True
+  register: terraform_checksums
+
 - name: Download Terraform
   get_url: url="https://releases.hashicorp.com/terraform/{{ terraform_version }}/terraform_{{ terraform_version }}_linux_amd64.zip"
            dest="/usr/local/src/terraform_{{ terraform_version }}_linux_amd64.zip"
+           checksum="sha256:{{ item.split(' ') | first }}"
+  with_items: "{{ terraform_checksums.content.split('\n') | select('search', 'linux_amd64') | list | first }}"
   register: terraform_downloaded
 
 - name: Extract and install Terraform


### PR DESCRIPTION
When the Terraform ZIP archive is downloaded, utilize the published SHA256 checksums to confirm the downloaded payload.

Fixes #7 

---

**Testing**

Tweak the `terraform_checksum` variable between the correct and incorrect value to ensure that it fails with an incorrect value while running:

```bash
$ molecule --version
molecule, version 1.25.0
$ molecule test
```

